### PR TITLE
Adding headers to support spring config server

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -654,6 +654,8 @@ func (t *HookTask) deliver() {
 
 	timeout := time.Duration(setting.Webhook.DeliverTimeout) * time.Second
 	req := httplib.Post(t.URL).SetTimeout(timeout, timeout).
+		Header("X-Github-Delivery", t.UUID).
+		Header("X-Github-Event", string(t.EventType)).
 		Header("X-Gogs-Delivery", t.UUID).
 		Header("X-Gogs-Signature", t.Signature).
 		Header("X-Gogs-Event", string(t.EventType)).


### PR DESCRIPTION
Spring cloud config server dependency spring cloud config monitor looks for X-Github-Event condition PropertyPathEndpoint.class -> GithubPropertyPathNotificationExtractor.class if ("push".equals(headers.getFirst("X-Github-Event"))) {...}

PropertyPathEndpoint -> notifyByPath() -> PropertyPathNotification notification = this.extractor.extract(headers, request); -> GithubPropertyPathNotificationExtractor -> extract -> has condition if ("push".equals(headers.getFirst("X-Github-Event"))) {...}

If we add these headers as part of webhook it will resolve the issue and we can integrate with spring config server.
